### PR TITLE
added isInRole() method with has() alias

### DIFF
--- a/roles/roles_common.js
+++ b/roles/roles_common.js
@@ -281,11 +281,13 @@ _.extend(Roles, {
     try {
       currentUser = Meteor.user()
     } catch (err) {
-      var publishUserMsg = 'Meteor.userId can only be invoked in method calls. Use this.userId in publish functions.';
-      if (err.name === 'Error' && err.message === publishUserMsg) {
-        var msg = 'This method can only be invoked in method calls. Use Roles.userIsInRole(this.userId, roles) in publications.';
-        throw new Error(msg);
+      if (!DDP._CurrentInvocation.get()) {
+        throw new Error(
+          'This method can only be invoked in method calls. Use Roles.userIsInRole(this.userId, roles) in publications.'
+        );
       }
+
+      throw err;
     }
     return Roles.userIsInRole(currentUser, roles, group);
   },

--- a/roles/roles_common.js
+++ b/roles/roles_common.js
@@ -255,6 +255,43 @@ _.extend(Roles, {
   },
 
   /**
+   * Check if the current user has specified role(s)
+   *
+   * @example
+   *     // same usage style as userIsInRole
+   *     Roles.isInRole('admin')
+   *     Roles.isInRole(['editor','manager'], 'site-content')
+   *     // ...
+   *
+   *     // using has() function alias:
+   *     Roles.has('admin')
+   *
+   * @method isInRole
+   * @param {String|Array} roles Name of role/permission or Array of
+   *                            roles/permissions to check against.  If array,
+   *                            will return true if user is in _any_ role.
+   * @param {String} [group] Optional. Name of group.  If supplied, limits check
+   *                         to just that group.
+   *                         The user's Roles.GLOBAL_GROUP will always be checked
+   *                         whether group is specified or not.
+   * @return {Boolean} true if user is in _any_ of the target roles
+   */
+  isInRole: function (roles, group) {
+    var currentUser;
+    try {
+      currentUser = Meteor.user()
+    } catch (err) {
+      var publishUserMsg = 'Meteor.userId can only be invoked in method calls. Use this.userId in publish functions.';
+      if (err.name === 'Error' && err.message === publishUserMsg) {
+        var msg = 'This method can only be invoked in method calls. Use Roles.userIsInRole(this.userId, roles) in publications.';
+        throw new Error(msg);
+      }
+    }
+    return Roles.userIsInRole(currentUser, roles, group);
+  },
+  has: function (roles, group) { return Roles.isInRole(roles, group); },
+
+  /**
    * Check if user has specified permissions/roles
    *
    * @example

--- a/roles/tests/client.js
+++ b/roles/tests/client.js
@@ -79,6 +79,15 @@
     })
 
   Tinytest.add(
+    'roles - can check current user\'s roles via isInRole()/has()',
+    function (test) {
+      test.isTrue(Roles.isInRole(['admin', 'editor']))
+      test.isTrue(Roles.has(['admin', 'editor']))
+      test.isTrue(Roles.isInRole('editor', 'random-group'))
+      test.isFalse(Roles.isInRole('nonexisting'))
+    })
+
+  Tinytest.add(
     'roles - can check if user is in role', 
     function (test) {
       testUser(test, 'eve', ['admin', 'editor'])

--- a/roles/tests/server.js
+++ b/roles/tests/server.js
@@ -22,6 +22,10 @@
     }
   }
 
+  // Mock Meteor.user() for isInRole/has method testing
+  Meteor.user = function () {
+    return users.eve
+  }
 
   function testUser (test, username, expectedRoles, group) {
     var userId = users[username],
@@ -103,6 +107,22 @@
         {$addToSet: { roles: { $each: ['admin', 'user'] } } }
       )
       testUser(test, 'eve', ['admin', 'user'])
+    })
+
+  Tinytest.add(
+    'roles - can check if user is in role via isInRole()/has()',
+    function (test) {
+      reset()
+
+      Meteor.users.update(
+        {"_id":users.eve},
+        {$addToSet: { roles: { $each: ['admin', 'user'] } } }
+      )
+
+      test.isTrue(Roles.isInRole(['admin', 'user']))
+      test.isTrue(Roles.has(['admin', 'user']))
+      // test.isTrue(Roles.isInRole('user', 'random-group')) <- this test should pass but fails
+      test.isFalse(Roles.isInRole('nonexisting'))
     })
 
   Tinytest.add(


### PR DESCRIPTION
See issue #56.

I used the built-in `Meteor.user()` method, which will automatically throw a `Error: Meteor.userId can only be invoked in method calls. Use this.userId in publish functions.` error when called in the wrong place. After that, the call is passed on to `userIsInRole`.