### PR TITLE
`getUsersInRole` now passes through query options to Meteor.users.find

### DIFF
--- a/roles/roles_common.js
+++ b/roles/roles_common.js
@@ -432,9 +432,11 @@ _.extend(Roles, {
    *                            specified but need not have _all_ roles.
    * @param {String} [group] Optional name of group to restrict roles to.
    *                         User's Roles.GLOBAL_GROUP will also be checked.
+   * @param {Object} [options] Optional set options identical to what you may
+   *                         pass to the Collection.find method.
    * @return {Cursor} cursor of users in role
    */
-  getUsersInRole: function (role, group) {
+  getUsersInRole: function (role, group, options) {
     var query,
         roles = role,
         groupQuery
@@ -480,7 +482,7 @@ _.extend(Roles, {
       query.$or.push({roles: {$in: roles}})
     }
 
-    return Meteor.users.find(query)
+    return Meteor.users.find(query, options);
   },  // end getUsersInRole 
   
   /**

--- a/roles/tests/server.js
+++ b/roles/tests/server.js
@@ -835,6 +835,20 @@
       test.equal(_.difference(expected, actual), [])
     })
 
+  Tinytest.add(
+    'roles - can get all users in role by group and passes through mongo query arguments', 
+    function (test) {
+      reset()
+      Roles.addUsersToRoles([users.eve, users.joe], ['admin', 'user'], 'group1')
+      Roles.addUsersToRoles([users.bob, users.joe], ['admin'], 'group2')
+
+      var results = Roles.getUsersInRole('admin','group1', { fields: { username: 0 }, limit: 1 }).fetch();
+
+      test.equal(1, results.length);
+      test.isTrue(results[0].hasOwnProperty('_id'));
+      test.isFalse(results[0].hasOwnProperty('username'));
+    })
+
 
   Tinytest.add(
     'roles - can use Roles.GLOBAL_GROUP to assign blanket permissions',


### PR DESCRIPTION
Makes `getUsersInRole` usable inside publish functions by granting the ability to limit the fields returned on the matching `Meteor.user` documents.

The PR accomplishes this by simply passing through an optional `options` object identical to the `Collection.find` options object to the final call to `Meteor.users.find`.

Test and documentation update included.