### PR TITLE
Switch to "new Mongo.Collection(...)"

### DIFF
--- a/roles/roles_common.js
+++ b/roles/roles_common.js
@@ -1,6 +1,12 @@
 ;(function () {
 
 /**
+ * Eliminate Meteor.Collection deprecation warning while maintaining
+ * backwards compatibility
+ */
+var Mongo = Mongo || _.pick(Meteor,'Collection');
+
+/**
  * Provides functions related to user authorization. Compatible with built-in Meteor accounts packages.
  *
  * @module Roles
@@ -11,7 +17,7 @@
  *   ex: { _id:<uuid>, name: "admin" }
  */
 if (!Meteor.roles) {
-  Meteor.roles = new Meteor.Collection("roles")
+  Meteor.roles = new Mongo.Collection("roles")
 }
 
 /**

--- a/roles/roles_server.js
+++ b/roles/roles_server.js
@@ -1,12 +1,17 @@
 ;(function () {
 
+/**
+ * Eliminate Meteor.Collection deprecation warning while maintaining
+ * backwards compatibility
+ */
+var Mongo = Mongo || _.pick(Meteor,'Collection');
 
 /**
  * Roles collection documents consist only of an id and a role name.
  *   ex: { _id:<uuid>, name: "admin" }
  */
 if (!Meteor.roles) {
-  Meteor.roles = new Meteor.Collection("roles")
+  Meteor.roles = new Mongo.Collection("roles")
 
   // Create default indexes for roles collection
   Meteor.roles._ensureIndex('name', {unique: 1})


### PR DESCRIPTION
This uses the "new Mongo.Collection(...)" call when its available. Maintains backward compatibility and eliminates the following warning on newer versions of meteor:

    Consider migrating from `new Meteor.Collection` to `new Mongo.Collection`
