### PR TITLE
Fix for userIsInRole helper: Check to handle when `userRoles` is null.

### DIFF
--- a/roles/roles_common.js
+++ b/roles/roles_common.js
@@ -308,6 +308,7 @@ _.extend(Roles, {
           return _.contains(userRoles, role)
         })
       } else if ('object' === typeof userRoles) {
+        if(!userRoles) return false
         // roles field is dictionary of groups
         found = _.isArray(userRoles[group]) && _.some(roles, function (role) {
           return _.contains(userRoles[group], role)

--- a/roles/roles_common.js
+++ b/roles/roles_common.js
@@ -307,8 +307,7 @@ _.extend(Roles, {
         return _.some(roles, function (role) {
           return _.contains(userRoles, role)
         })
-      } else if ('object' === typeof userRoles) {
-        if(!userRoles) return false
+      } else if (userRoles && 'object' === typeof userRoles) {
         // roles field is dictionary of groups
         found = _.isArray(userRoles[group]) && _.some(roles, function (role) {
           return _.contains(userRoles[group], role)


### PR DESCRIPTION
Certain race conditions can cause `userRoles` to be `null` and an exception to be thrown.   Even while wrapping with `currentUser` helper:

   {{#if currentUser}}
      {{#if isInRole 'coach'}} ....

`typeof(null)` returns "object" so the check on the previous line is not enough to avoid a js exception: `'object' === typeof userRoles`.

@alanning I'll be at Devshop tomorrow if there's anything to discuss :)