### PR TITLE
fix #174 Drop mongodb roles index "name_1" in _forwardMigrate

### DIFF
--- a/roles/roles_common.js
+++ b/roles/roles_common.js
@@ -76,7 +76,7 @@ _.extend(Roles, {
       // XXX string parsing sucks, maybe
       // https://jira.mongodb.org/browse/SERVER-3069 will get fixed one day
       if (e.name !== 'MongoError') throw e;
-      match = e.err.match(/E11000 duplicate key error index: ([^ ]+)/);
+      match = ( e.err || e.errmsg ).match(/E11000 duplicate key error index: ([^ ]+)/);
       if (!match) throw e;
       if (match[1].indexOf('$_id') !== -1) {
         if (options.unlessExists) return null;

--- a/roles/roles_server.js
+++ b/roles/roles_server.js
@@ -248,6 +248,9 @@ _.extend(Roles, {
     updateUser = updateUser || Roles._defaultUpdateUser;
     updateRole = updateRole || Roles._defaultUpdateRole;
 
+    //drop old index, preventing mongo duplicate key 'null' errors
+    Meteor.roles._dropIndex("name_1");
+
     Meteor.roles.find().forEach(function (role, index, cursor) {
       if (!Roles._isNewRole(role)) {
         updateRole(role, Roles._convertToNewRole(role));

--- a/roles/roles_server.js
+++ b/roles/roles_server.js
@@ -7,7 +7,7 @@ Meteor.users._ensureIndex({'roles.partition': 1});
 
 /*
  * Publish logged-in user's roles so client-side checks can work.
- * 
+ *
  * Use a named publish function so clients can check `ready()` state.
  */
 Meteor.publish('_roles', function () {
@@ -248,8 +248,14 @@ _.extend(Roles, {
     updateUser = updateUser || Roles._defaultUpdateUser;
     updateRole = updateRole || Roles._defaultUpdateRole;
 
-    //drop old index, preventing mongo duplicate key 'null' errors
-    Meteor.roles._dropIndex("name_1");
+    // drop old index, preventing mongo duplicate key 'null' errors
+    try {
+      Meteor.roles._dropIndex("name_1");
+    } catch (e) {
+      if (e.name !== 'MongoError') throw e;
+      match = (e.err || e.errmsg).match(/index not found/);
+      if (!match) throw e;
+    }
 
     Meteor.roles.find().forEach(function (role, index, cursor) {
       if (!Roles._isNewRole(role)) {


### PR DESCRIPTION
See #174

**WARNING** : throws an exception if index "name_1" does not exists. Any reason to think this might happen? 
In that case, might want to surround it with a try catch block and print a warning.