### PR TITLE
Fix mistake in removeUsersFromRoles comment

### DIFF
--- a/docs/classes/Roles.html
+++ b/docs/classes/Roles.html
@@ -1756,7 +1756,7 @@ used automatically.</p>
                     
 
                     <div class="param-description">
-                        <p>Name(s) of roles to add users to</p>
+                        <p>Name(s) of roles to remove users from</p>
 
                     </div>
 

--- a/docs/data.json
+++ b/docs/data.json
@@ -279,7 +279,7 @@
                 },
                 {
                     "name": "roles",
-                    "description": "Name(s) of roles to add users to",
+                    "description": "Name(s) of roles to remove users from",
                     "type": "Array|String"
                 },
                 {

--- a/docs/files/roles_roles_common.js.html
+++ b/docs/files/roles_roles_common.js.html
@@ -279,7 +279,7 @@ _.extend(Roles, {
    *
    * @method removeUsersFromRoles
    * @param {Array|String} users User id(s) or object(s) with an _id field
-   * @param {Array|String} roles Name(s) of roles to add users to
+   * @param {Array|String} roles Name(s) of roles to remove users from
    * @param {String} [group] Optional. Group name. If supplied, only that
    *                         group will have roles removed.
    */

--- a/roles/roles_common.js
+++ b/roles/roles_common.js
@@ -185,7 +185,7 @@ _.extend(Roles, {
    *
    * @method removeUsersFromRoles
    * @param {Array|String} users User id(s) or object(s) with an _id field
-   * @param {Array|String} roles Name(s) of roles to add users to
+   * @param {Array|String} roles Name(s) of roles to remove users from
    * @param {String} [group] Optional. Group name. If supplied, only that
    *                         group will have roles removed.
    */


### PR DESCRIPTION
Change the documentation for the role field for `removeUsersFromRoles` from "Name(s) of roles to add users" to "Name(s) of roles to remove users from".